### PR TITLE
Fix ManyToMany join table  column key mismatch.

### DIFF
--- a/src/main/java/muni/fi/revrec/model/pullRequest/PullRequest.java
+++ b/src/main/java/muni/fi/revrec/model/pullRequest/PullRequest.java
@@ -28,7 +28,9 @@ public class PullRequest {
     private Integer changeNumber;
     private Long timestamp;
 
-    @JoinTable(name = "review")
+    @JoinTable(name = "review", joinColumns = {@JoinColumn(name = "pull_request_id", referencedColumnName = "id")},
+    inverseJoinColumns = {@JoinColumn(name = "reviewer_id", referencedColumnName = "id")})
+    //@JoinTable(name = "review")
     @ManyToMany(fetch = FetchType.EAGER)
     private Set<Developer> reviewers;
 


### PR DESCRIPTION
If we start as a whole new project, the SQL file provided is not suitable for JPA. JPA will create table review like below:
``` 
CREATE TABLE `review` (
  `pull_request_id` int(11) NOT NULL,
  `reviewers_id` int(11) NOT NULL,
  PRIMARY KEY (`pull_request_id`,`reviewers_id`),
  KEY `FK3wktecalsldhdbgafdea1fth9` (`reviewers_id`),
  CONSTRAINT `FK3wktecalsldhdbgafdea1fth9` FOREIGN KEY (`reviewers_id`) REFERENCES `developer` (`id`),
  CONSTRAINT `FKtqhdcofpdsoo5bqu62lyssja3` FOREIGN KEY (`pull_request_id`) REFERENCES `pull_request` (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=latin1 
```
but in the SQL file, `reviewers_id` should be `reviewer_id`.
So I specified the details of how to create the join table in `PullRequest.java`.